### PR TITLE
nrf52-network updates

### DIFF
--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -4,6 +4,7 @@ import logging
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.components.psram import is_guaranteed as psram_is_guaranteed
+from esphome.components.zephyr import zephyr_add_prj_conf
 import esphome.config_validation as cv
 from esphome.const import CONF_ENABLE_IPV6, CONF_MIN_IPV6_ADDR_COUNT
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
@@ -105,28 +106,37 @@ def has_high_performance_networking() -> bool:
     return CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
 
 
+def _validate_nrf52(value):
+    if CORE.is_nrf52 and not value:
+        raise cv.Invalid("nRF52 requires IPv6 to be enabled.")
+    return value
+
+
 CONFIG_SCHEMA = cv.Schema(
     {
-        # IPv6 configuration (not applicable to nRF52 - always enabled for Thread)
         cv.SplitDefault(
             CONF_ENABLE_IPV6,
             esp8266=False,
             esp32=False,
             rp2040=False,
             bk72xx=False,
+            host=False,
+            nrf52=True,
         ): cv.All(
             cv.boolean,
             cv.Any(
                 cv.require_framework_version(
-                    bk72xx_arduino=cv.Version(1, 7, 0),
                     esp_idf=cv.Version(0, 0, 0),
                     esp32_arduino=cv.Version(0, 0, 0),
                     esp8266_arduino=cv.Version(0, 0, 0),
-                    host=cv.Version(0, 0, 0),
                     rp2040_arduino=cv.Version(0, 0, 0),
+                    bk72xx_arduino=cv.Version(1, 7, 0),
+                    host=cv.Version(0, 0, 0),
+                    nrf52_zephyr=cv.Version(0, 0, 0),
                 ),
                 cv.boolean_false,
             ),
+            _validate_nrf52,
         ),
         cv.Optional(CONF_MIN_IPV6_ADDR_COUNT, default=0): cv.positive_int,
         cv.Optional(CONF_ENABLE_HIGH_PERFORMANCE): cv.All(cv.boolean, cv.only_on_esp32),
@@ -139,6 +149,10 @@ async def to_code(config):
     cg.add_define("USE_NETWORK")
     if CORE.using_arduino and CORE.is_esp32:
         cg.add_library("Networking", None)
+    elif CORE.using_zephyr:
+        zephyr_add_prj_conf("NETWORKING", True)
+        zephyr_add_prj_conf("NET_TCP", True)
+        zephyr_add_prj_conf("NET_UDP", True)
 
     # Apply high performance networking settings
     # Config can explicitly enable/disable, or default to component-driven behavior
@@ -203,10 +217,7 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RECVMBOX_SIZE", 64)
             add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_RECVMBOX_SIZE", 64)
 
-    # Force IPv6 for nRF52 (Thread is IPv6-only)
-    enable_ipv6 = True if CORE.is_nrf52 else config.get(CONF_ENABLE_IPV6, None)
-
-    if enable_ipv6 is not None:
+    if (enable_ipv6 := config.get(CONF_ENABLE_IPV6, None)) is not None:
         cg.add_define("USE_NETWORK_IPV6", enable_ipv6)
         if enable_ipv6:
             cg.add_define(
@@ -219,6 +230,9 @@ async def to_code(config):
             else:
                 add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", True)
                 add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", True)
+        elif CORE.is_nrf52:
+            zephyr_add_prj_conf("NET_IPV6", True)
+            zephyr_add_prj_conf("NET_IPV4", False)
         elif enable_ipv6:
             cg.add_build_flag("-DCONFIG_LWIP_IPV6")
             cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")

--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -28,13 +28,11 @@
 #endif
 
 #ifdef USE_ZEPHYR
-// Zephyr networking uses IPv6-only for Thread
+// Zephyr networking only supports IPv6
 using ip_addr_t = in6_addr;
 using ip6_addr_t = in6_addr;
-// IPv6-only address parsing
 static inline int ipaddr_aton(const char *cp, ip_addr_t *addr) { return inet_pton(AF_INET6, cp, addr) == 1 ? 1 : 0; }
 #elif defined(USE_HOST)
-// HOST platform uses IPv4 addresses
 using ip_addr_t = in_addr;
 using ip4_addr_t = in_addr;
 #define ipaddr_aton(x, y) inet_aton((x), (y))
@@ -59,72 +57,37 @@ namespace network {
 struct IPAddress {
  public:
 #ifdef USE_ZEPHYR
-  // Zephyr networking IPv6-only implementation for Thread
+  // Zephyr networking IPv6-only implementation
   IPAddress() { memset(&ip_addr_, 0, sizeof(ip_addr_)); }
   IPAddress(const std::string &in_address) { ipaddr_aton(in_address.c_str(), &ip_addr_); }
   IPAddress(const ip_addr_t *other_ip) { ip_addr_ = *other_ip; }
 
   operator ip_addr_t() const { return ip_addr_; }
 
-  bool is_set() {
-    // Check if address is all zeros
-    for (int i = 0; i < 16; i++) {
-      if (ip_addr_.s6_addr[i] != 0)
-        return true;
-    }
-    return false;
-  }
+  bool is_set() { return !net_ipv6_is_addr_unspecified(&ip_addr_); }
   bool is_ip4() { return false; }
   bool is_ip6() { return this->is_set(); }
-  bool is_multicast() {
-    // For IPv6, check if first byte is 0xff
-    return ip_addr_.s6_addr[0] == 0xff;
-  }
+  bool is_multicast() { return net_ipv6_is_addr_mcast(&ip_addr_); }
   std::string str() const {
     char buffer[INET6_ADDRSTRLEN];
     inet_ntop(AF_INET6, &ip_addr_, buffer, sizeof(buffer));
     return str_lower_case(buffer);
   }
-  bool operator==(const IPAddress &other) const { return memcmp(&ip_addr_, &other.ip_addr_, sizeof(ip_addr_)) == 0; }
-  bool operator!=(const IPAddress &other) const { return memcmp(&ip_addr_, &other.ip_addr_, sizeof(ip_addr_)) != 0; }
+  bool operator==(const IPAddress &other) const { return net_ipv6_addr_cmp(&ip_addr_, &other.ip_addr_); }
+  bool operator!=(const IPAddress &other) const { return !net_ipv6_addr_cmp(&ip_addr_, &other.ip_addr_); }
   IPAddress &operator+=(uint8_t increase) {
-    // Increment last byte of IPv6 address
-    ip_addr_.s6_addr[15] += increase;
+    ip_addr_.s6_addr32[3] += increase;
     return *this;
   }
 
 #elif defined(USE_HOST)
-  // HOST platform IPv4 implementation
   IPAddress() { ip_addr_.s_addr = 0; }
   IPAddress(uint8_t first, uint8_t second, uint8_t third, uint8_t fourth) {
     this->ip_addr_.s_addr = htonl((first << 24) | (second << 16) | (third << 8) | fourth);
   }
-  IPAddress(const std::string &in_address) { ipaddr_aton(in_address.c_str(), &ip_addr_); }
+  IPAddress(const std::string &in_address) { inet_aton(in_address.c_str(), &ip_addr_); }
   IPAddress(const ip_addr_t *other_ip) { ip_addr_ = *other_ip; }
-
-  operator ip_addr_t() const { return ip_addr_; }
-
-  bool is_set() { return ip_addr_.s_addr != 0; }
-  bool is_ip4() { return true; }
-  bool is_ip6() { return false; }
-  bool is_multicast() {
-    uint32_t addr = ntohl(ip_addr_.s_addr);
-    return (addr & 0xF0000000) == 0xE0000000;
-  }
-  std::string str() const {
-    char buffer[INET_ADDRSTRLEN];
-    inet_ntop(AF_INET, &ip_addr_, buffer, sizeof(buffer));
-    return str_lower_case(buffer);
-  }
-  bool operator==(const IPAddress &other) const { return ip_addr_.s_addr == other.ip_addr_.s_addr; }
-  bool operator!=(const IPAddress &other) const { return ip_addr_.s_addr != other.ip_addr_.s_addr; }
-  IPAddress &operator+=(uint8_t increase) {
-    uint32_t addr = ntohl(ip_addr_.s_addr);
-    addr += increase;
-    ip_addr_.s_addr = htonl(addr);
-    return *this;
-  }
-
+  std::string str() const { return str_lower_case(inet_ntoa(ip_addr_)); }
 #else
   IPAddress() { ip_addr_set_zero(&ip_addr_); }
   IPAddress(uint8_t first, uint8_t second, uint8_t third, uint8_t fourth) {

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -300,7 +300,6 @@
 #define USE_NRF52_UICR_ERASE
 #define USE_SOFTDEVICE_ID 7
 #define USE_SOFTDEVICE_VERSION 1
-#define USE_ZEPHYR_NETWORKING
 #endif
 
 // Disabled feature flags


### PR DESCRIPTION
Here's a few updates to the ipv6 support for zephyr/nrf52.

Summary of changes:
* Changed the network configuration so that it's possible to set the variable enable_ipv6.
* Added validation for the nrf52 platform of enable_ipv6
* Added zephyr project configuration options to enable networking/ipv6
* Removed host changes from the ip_address implementation
* Cleaned up the ip_address.h implementation to use Zephy api functions whenever possible