### PR TITLE
[zephyr] Add I2C test coverage for SiWx917

### DIFF
--- a/tests/components/i2c/test.zephyr-siwx917.yaml
+++ b/tests/components/i2c/test.zephyr-siwx917.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/zephyr-siwx917.yaml
+
+<<: !include common.yaml

--- a/tests/test_build_components/common/i2c/zephyr-siwx917.yaml
+++ b/tests/test_build_components/common/i2c/zephyr-siwx917.yaml
@@ -1,0 +1,10 @@
+# Common I2C configuration for platform: zephyr, variant: siwx917 tests
+# No sda/scl: siwx917 doesn't support I2C pin remapping (see siwx917.py's own
+# comment) -- the board's default I2C bus (ulpi2c, aliased zephyr_i2c) is
+# already wired by the board's own DTS. Confirmed on real hardware: an HTU21D
+# (SI7021) at 0x40 and a VEML7700 at 0x29 both scan and read correctly with no
+# sda/scl given at all.
+
+i2c:
+  - id: i2c_bus
+    scan: true


### PR DESCRIPTION
Stacked on esphomeplatformzephyr/esphome#149 (this branch isn't in the org repo yet, so this PR lives on my own fork for now -- will move to a real stacked PR against esphomeplatformzephyr/esphome once #149 merges).

Adds I2C bus test coverage for the `SIWX917` variant.

Validated on real hardware: an HTU21D (SI7021, address 0x40) and a VEML7700 (address 0x29) both scan and read correctly on the board's default I2C bus (`ulpi2c`, aliased `zephyr_i2c`) with **no `sda`/`scl` given at all** -- this variant doesn't support I2C pin remapping (see `siwx917.py`), so the test package only exercises the board-default bus.

## Types of changes

- [ ] Bugfix
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
- Follow-up to esphomeplatformzephyr/esphome#149 / esphomeplatformzephyr/esphome#147

## Test Environment
Real Silicon Labs SiWx917-DK2605A (BRD2605A) hardware, same as #149.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).